### PR TITLE
fix typo for input component select

### DIFF
--- a/data-application/en/input-component-select.mdx
+++ b/data-application/en/input-component-select.mdx
@@ -14,7 +14,7 @@ icon: 'caret-down'
 `<Select>` is a component for inputting values in a selection format to the state declared by the `defineState()` function.
 
 ```tsx
-import { defineState } from '@morph-data/components;
+import { defineState } from '@morph-data/components';
 
 export const { category } = defineState({ category: 'book' });
 
@@ -59,7 +59,7 @@ There are two ways to pass values to Select Items.
 ```tsx
 <SelectItems>
   // 1. Specify as an array
-  <SelectItems 
+  <SelectItems
     items={[
       {value: 'book', label: 'Book' },
       { value: 'electronics', label: 'Electronics' }


### PR DESCRIPTION
## Describe your changes

- fix typo in select component page (shortage of comma)

## GitHub Issue Link (if applicable)
none